### PR TITLE
Enhance RunCommand Extension with Append/Prepend Functionality

### DIFF
--- a/source/RunCommand.popclipext/Config.json
+++ b/source/RunCommand.popclipext/Config.json
@@ -1,7 +1,7 @@
 {
   "name": "Terminal",
   "identifier": "com.pilotmoon.popclip.extension.rtc",
-  "description": "Run the selected text as a command in the active terminal window. Supports Terminal, iTerm2 and Warp.",
+  "description": "Run the selected text as a command in the active terminal window with optional prepend/append text. Supports Terminal, iTerm2 and Warp.",
   "keywords": "terminal iterm2 warp run command",
   "popclip version": 4151,
   "icon": "RTC.png",
@@ -38,6 +38,18 @@
       "values": ["Terminal", "iTerm2 v2.9+", "Warp"],
       "valueLabels": ["Terminal", "iTerm2", "Warp"],
       "identifier": "term"
+    },
+    {
+      "label": "Prepend Command",
+      "type": "string",
+      "identifier": "prepend",
+      "description": "Text to insert before the selected text (optional)"
+    },
+    {
+      "label": "Append Command",
+      "type": "string",
+      "identifier": "append",
+      "description": "Text to insert after the selected text (optional)"
     }
   ]
 }

--- a/source/RunCommand.popclipext/README.md
+++ b/source/RunCommand.popclipext/README.md
@@ -4,12 +4,40 @@ Runs the selected text as a command in the current terminal window.
 
 One can choose either default Terminal, [iTerm2](https://iterm2.com/) or [Warp](https://www.warp.dev/).
 
+## Features
+
+- Execute selected text as a command in your terminal of choice
+- Optionally prepend text before the selected command
+- Optionally append text after the selected command
+
+### Usage Examples
+
+1. **Basic command execution**:  
+   Select a command like `ls -la` and run it directly.
+
+2. **Prepend example**:  
+   Set "Prepend Command" to `sudo` to run selected commands with sudo privileges.
+
+3. **Append example**:  
+   Set "Append Command" to `| grep keyword` to filter command output.
+
+4. **Combining prepend and append**:  
+   Set "Prepend Command" to `sudo` and "Append Command" to `| tee output.log` to run with sudo and save output to a file.
+
+## Configuration
+
+In the extension settings, you can configure:
+- Terminal Emulator: Choose between Terminal, iTerm2, or Warp
+- Prepend Command: Text to insert before the selected text (optional)
+- Append Command: Text to insert after the selected text (optional)
+
 ### About
 
-Original extension and icon created by [James Smith](https://twitter.com/smithjw/status/244757999665700864). iTerm2 option added by [honnix](https://github.com/honnix). Warp support added by Oliver using script from [parterburn](https://gist.github.com/parterburn/e832b9090ee35eb830529de8bd978b82).
+Original extension and icon created by [James Smith](https://twitter.com/smithjw/status/244757999665700864). iTerm2 option added by [honnix](https://github.com/honnix). Warp support added by Oliver using script from [parterburn](https://gist.github.com/parterburn/e832b9090ee35eb830529de8bd978b82). Prepend/append functionality added by Shayon Pal.
 
 ## Changelog
 
+- 28 May 2025: Added prepend/append functionality to customize command execution
 - 9 Nov 2024: Remove needless line from iTerm2 script
 - 21 May 2024: Add filter keywords for directory and update readme.
 - 28 Mar 2024: Removed the legacy iTerm option and added Warp Terminal.

--- a/source/RunCommand.popclipext/iterm2.applescript
+++ b/source/RunCommand.popclipext/iterm2.applescript
@@ -2,7 +2,20 @@
 tell application id "com.googlecode.iterm2"
 	activate
 	set _session to current session of current window
+	
+	-- Prepare the command with optional prepend/append text
+	set prepend_text to "{popclip option prepend}"
+	set append_text to "{popclip option append}"
+	
 	tell _session
-		write text "{popclip text}"
+		if prepend_text is not "" and append_text is not "" then
+			write text prepend_text & " {popclip text} " & append_text
+		else if prepend_text is not "" then
+			write text prepend_text & " {popclip text}"
+		else if append_text is not "" then
+			write text "{popclip text} " & append_text
+		else
+			write text "{popclip text}"
+		end if
 	end tell
 end tell

--- a/source/RunCommand.popclipext/terminal.applescript
+++ b/source/RunCommand.popclipext/terminal.applescript
@@ -5,5 +5,18 @@ tell application "Terminal"
         do script ""
     end if
     set theTab to selected tab in first window
-    do script "{popclip text}" in theTab
+    
+    -- Prepare the command with optional prepend/append text
+    set prepend_text to "{popclip option prepend}"
+    set append_text to "{popclip option append}"
+    
+    if prepend_text is not "" and append_text is not "" then
+        do script prepend_text & " {popclip text} " & append_text in theTab
+    else if prepend_text is not "" then
+        do script prepend_text & " {popclip text}" in theTab
+    else if append_text is not "" then
+        do script "{popclip text} " & append_text in theTab
+    else
+        do script "{popclip text}" in theTab
+    end if
 end tell

--- a/source/RunCommand.popclipext/warp.applescript
+++ b/source/RunCommand.popclipext/warp.applescript
@@ -59,4 +59,17 @@ else
 end if
 
 call_forward()
-send_text("{popclip text}")
+
+-- Prepare the command with optional prepend/append text
+set prepend_text to "{popclip option prepend}"
+set append_text to "{popclip option append}"
+
+if prepend_text is not "" and append_text is not "" then
+	send_text(prepend_text & " {popclip text} " & append_text)
+else if prepend_text is not "" then
+	send_text(prepend_text & " {popclip text}")
+else if append_text is not "" then
+	send_text("{popclip text} " & append_text)
+else
+	send_text("{popclip text}")
+end if


### PR DESCRIPTION
## Summary
This PR enhances the RunCommand extension to allow users to append or prepend custom commands to the selected text before execution in the terminal.

### Changes
- Add new configuration options for prepend and append commands
- Modify the AppleScript files to handle the new options
- Update documentation with usage examples and configuration details

## Testing
- Tested with Terminal.app, iTerm2, and Warp
- Verified that all combinations of prepend/append work correctly

Closes #1